### PR TITLE
Disable PHPStan and syntax error lints

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -11,4 +11,7 @@ projects:
       - src: CortexPE/Commando/Commando
         version: ^3.0.0
         branch: PM4
+    lint:
+      phpstan: false
+      syntaxError: false
 ...


### PR DESCRIPTION
Poggit still uses PHP 7.4 and only checks for PM3 PHPStan