### PR TITLE
Fix: mysql error correct bind_param types & length for account insert…

### DIFF
--- a/src/cooldogedev/BedrockEconomy/database/mysql/InsertionQuery.php
+++ b/src/cooldogedev/BedrockEconomy/database/mysql/InsertionQuery.php
@@ -70,7 +70,7 @@ final class InsertionQuery extends MySQLQuery
 
         // insert account
         $insertionQuery = $connection->prepare("INSERT IGNORE INTO " . $this->table . " (xuid, username, amount) VALUES (?, ?, ?)");
-        $insertionQuery->bind_param("ssii", $this->getRef($this->xuid), $this->getRef($this->username), $amount);
+        $insertionQuery->bind_param("sss", $this->getRef($this->xuid), $this->getRef($this->username), $amount);
         $insertionQuery->execute();
 
         if ($insertionQuery->affected_rows === 0) {


### PR DESCRIPTION
I had this error when an account was inserted:  

> **The number of elements in the type definition string must match the number of bind variables**

It was not working, so I checked on the database.  
Here’s what I did to fix it:

- Changed `bind_param` from **`"ssii"`** to **`"sss"`** to match the **3 placeholders** in the query.  
  *(I prefer using string for the amount — MySQL automatically casts it.)*
- Tested on **MySQL 8.0** with a fresh table and the account insertion now works.

> BTW, I think you need to update the configuration on **libSQL**:  
> change `schema` to `database`.  
> I had an error, made that change, and it worked!

Thanks for your time, and sorry for my bad English.
