### PR TITLE
Add Ukrainian and Russian translations

### DIFF
--- a/resources/languages/ru-RU.yml
+++ b/resources/languages/ru-RU.yml
@@ -10,7 +10,7 @@ error.amount.large: "&cВведённая сумма слишком велика
 
 error.rich.no_records: "&cНет записей для отображения."
 
-error.pay.self: "&cВы не можете платить самому себе."
+error.pay.self: "&cВы не можете переводить самому себе."
 
 balance.info: "&aВаш текущий баланс: &e{amount}&a. (#{position})"
 balance.info.other: "&aТекущий баланс {player}: &e{amount}&a. (#{position})"

--- a/resources/languages/ru-RU.yml
+++ b/resources/languages/ru-RU.yml
@@ -15,7 +15,7 @@ error.pay.self: "&cВы не можете платить самому себе."
 balance.info: "&aВаш текущий баланс: &e{amount}&a. (#{position})"
 balance.info.other: "&aТекущий баланс {player}: &e{amount}&a. (#{position})"
 
-balance.pay: "&aВы заплатили &f{amount}&a игроку {player}."
+balance.pay: "&aВы перевели &f{amount}&a игроку {player}."
 balance.pay.receive: "&aВы получили &f{amount}&a от игрока {player}."
 
 balance.add: "&aВы добавили &e{amount}&a на баланс игрока {player}."
@@ -34,7 +34,7 @@ commands:
     aliases: [ ]
   pay:
     name: pay
-    description: "Переводит деньги другим игрокам с вашего баланса"
+    description: "Перевести деньги другому игроку"
     usage: "&cИспользование: /pay <игрок: string> <сумма: number>"
     aliases: [ ]
   rich:

--- a/resources/languages/ru-RU.yml
+++ b/resources/languages/ru-RU.yml
@@ -1,0 +1,60 @@
+---
+error.database: "&cПроизошла неизвестная ошибка при обработке вашего запроса. Пожалуйста, повторите попытку позже."
+
+error.account.nonexistent: "&cУчётная запись, к которой вы пытаетесь получить доступ, не существует."
+error.account.insufficient: "&cНедостаточно средств."
+
+error.amount.invalid: "&cВведённая сумма недействительна."
+error.amount.small: "&cВведённая сумма слишком мала."
+error.amount.large: "&cВведённая сумма слишком велика."
+
+error.rich.no_records: "&cНет записей для отображения."
+
+error.pay.self: "&cВы не можете платить самому себе."
+
+balance.info: "&aВаш текущий баланс: &e{amount}&a. (#{position})"
+balance.info.other: "&aТекущий баланс {player}: &e{amount}&a. (#{position})"
+
+balance.pay: "&aВы заплатили &f{amount}&a игроку {player}."
+balance.pay.receive: "&aВы получили &f{amount}&a от игрока {player}."
+
+balance.add: "&aВы добавили &e{amount}&a на баланс игрока {player}."
+balance.remove: "&aВы сняли &e{amount}&a с баланса игрока {player}."
+balance.set: "&aВы установили баланс игрока {player} на &e{amount}&a."
+
+rich.header: "&aСамые богатые игроки:"
+rich.entry: "&e{position}. &a{player} - &e{amount}"
+rich.footer: "&aВы на данный момент на &e#{position}&a месте."
+
+commands:
+  balance:
+    name: balance
+    description: "Отображает ваш текущий баланс"
+    usage: "&cИспользование: /balance [игрок: string]"
+    aliases: [ ]
+  pay:
+    name: pay
+    description: "Переводит деньги другим игрокам с вашего баланса"
+    usage: "&cИспользование: /pay <игрок: string> <сумма: number>"
+    aliases: [ ]
+  rich:
+    name: rich
+    description: "Отображает самых богатых игроков"
+    usage: "&cИспользование: /rich [страница: number]"
+    aliases: [ ]
+  add-balance:
+    name: addbalance
+    description: "Добавляет деньги на баланс игрока"
+    usage: "&cИспользование: /addbalance <игрок: string> <сумма: number>"
+    aliases: [ ]
+  remove-balance:
+    name: removebalance
+    description: "Снимает деньги с баланса игрока"
+    usage: "&cИспользование: /removebalance <игрок: string> <сумма: number>"
+    aliases: [ ]
+  set-balance:
+    name: setbalance
+    description: "Устанавливает баланс игрока"
+    usage: "&cИспользование: /setbalance <игрок: string> <сумма: number>"
+    aliases: [ ]
+...

--- a/resources/languages/ru-RU.yml
+++ b/resources/languages/ru-RU.yml
@@ -30,31 +30,31 @@ commands:
   balance:
     name: balance
     description: "Отображает ваш текущий баланс"
-    usage: "&cИспользование: /balance [игрок: string]"
+    usage: "&cИспользование: /balance [player: string]"
     aliases: [ ]
   pay:
     name: pay
     description: "Перевести деньги другому игроку"
-    usage: "&cИспользование: /pay <игрок: string> <сумма: number>"
+    usage: "&cИспользование: /pay <player: string> <amount: number>"
     aliases: [ ]
   rich:
     name: rich
     description: "Отображает самых богатых игроков"
-    usage: "&cИспользование: /rich [страница: number]"
+    usage: "&cИспользование: /rich [page: number]"
     aliases: [ ]
   add-balance:
     name: addbalance
     description: "Добавляет деньги на баланс игрока"
-    usage: "&cИспользование: /addbalance <игрок: string> <сумма: number>"
+    usage: "&cИспользование: /addbalance <player: string> <amount: number>"
     aliases: [ ]
   remove-balance:
     name: removebalance
     description: "Снимает деньги с баланса игрока"
-    usage: "&cИспользование: /removebalance <игрок: string> <сумма: number>"
+    usage: "&cИспользование: /removebalance <player: string> <amount: number>"
     aliases: [ ]
   set-balance:
     name: setbalance
     description: "Устанавливает баланс игрока"
-    usage: "&cИспользование: /setbalance <игрок: string> <сумма: number>"
+    usage: "&cИспользование: /setbalance <player: string> <amount: number>"
     aliases: [ ]
 ...

--- a/resources/languages/uk-UA.yml
+++ b/resources/languages/uk-UA.yml
@@ -15,7 +15,7 @@ error.pay.self: "&cВи не можете платити самому собі."
 balance.info: "&aВаш поточний баланс: &e{amount}&a. (#{position})"
 balance.info.other: "&aПоточний баланс {player}: &e{amount}&a. (#{position})"
 
-balance.pay: "&aВи заплатили &f{amount}&a гравцю {player}."
+balance.pay: "&aВи переказали &f{amount}&a гравцю {player}."
 balance.pay.receive: "&aВи отримали &f{amount}&a від гравця {player}."
 
 balance.add: "&aВи додали &e{amount}&a до балансу гравця {player}."
@@ -34,7 +34,7 @@ commands:
     aliases: [ ]
   pay:
     name: pay
-    description: "Переказує гроші іншим гравцям з вашого балансу"
+    description: "Переказати гроші іншому гравцю"
     usage: "&cВикористання: /pay <гравець: string> <сума: number>"
     aliases: [ ]
   rich:

--- a/resources/languages/uk-UA.yml
+++ b/resources/languages/uk-UA.yml
@@ -1,0 +1,60 @@
+---
+error.database: "&cВиникла невідома помилка під час обробки вашого запиту. Будь ласка, спробуйте ще раз пізніше."
+
+error.account.nonexistent: "&cОбліковий запис, до якого ви намагаєтеся отримати доступ, не існує."
+error.account.insufficient: "&cНедостатньо коштів."
+
+error.amount.invalid: "&cВведена сума недійсна."
+error.amount.small: "&cВведена сума занадто мала."
+error.amount.large: "&cВведена сума занадто велика."
+
+error.rich.no_records: "&cНемає записів для відображення."
+
+error.pay.self: "&cВи не можете платити самому собі."
+
+balance.info: "&aВаш поточний баланс: &e{amount}&a. (#{position})"
+balance.info.other: "&aПоточний баланс {player}: &e{amount}&a. (#{position})"
+
+balance.pay: "&aВи заплатили &f{amount}&a гравцю {player}."
+balance.pay.receive: "&aВи отримали &f{amount}&a від гравця {player}."
+
+balance.add: "&aВи додали &e{amount}&a до балансу гравця {player}."
+balance.remove: "&aВи зняли &e{amount}&a з балансу гравця {player}."
+balance.set: "&aВи встановили баланс гравця {player} на &e{amount}&a."
+
+rich.header: "&aНайбагатші гравці:"
+rich.entry: "&e{position}. &a{player} - &e{amount}"
+rich.footer: "&aВи наразі на &e#{position}&a місці."
+
+commands:
+  balance:
+    name: balance
+    description: "Відображає ваш поточний баланс"
+    usage: "&cВикористання: /balance [гравець: string]"
+    aliases: [ ]
+  pay:
+    name: pay
+    description: "Переказує гроші іншим гравцям з вашого балансу"
+    usage: "&cВикористання: /pay <гравець: string> <сума: number>"
+    aliases: [ ]
+  rich:
+    name: rich
+    description: "Відображає найбагатших гравців"
+    usage: "&cВикористання: /rich [сторінка: number]"
+    aliases: [ ]
+  add-balance:
+    name: addbalance
+    description: "Додає гроші на баланс гравця"
+    usage: "&cВикористання: /addbalance <гравець: string> <сума: number>"
+    aliases: [ ]
+  remove-balance:
+    name: removebalance
+    description: "Знімає гроші з балансу гравця"
+    usage: "&cВикористання: /removebalance <гравець: string> <сума: number>"
+    aliases: [ ]
+  set-balance:
+    name: setbalance
+    description: "Встановлює баланс гравця"
+    usage: "&cВикористання: /setbalance <гравець: string> <сума: number>"
+    aliases: [ ]
+...

--- a/resources/languages/uk-UA.yml
+++ b/resources/languages/uk-UA.yml
@@ -10,7 +10,7 @@ error.amount.large: "&cВведена сума занадто велика."
 
 error.rich.no_records: "&cНемає записів для відображення."
 
-error.pay.self: "&cВи не можете платити самому собі."
+error.pay.self: "&cВи не можете переказувати самому собі."
 
 balance.info: "&aВаш поточний баланс: &e{amount}&a. (#{position})"
 balance.info.other: "&aПоточний баланс {player}: &e{amount}&a. (#{position})"

--- a/resources/languages/uk-UA.yml
+++ b/resources/languages/uk-UA.yml
@@ -30,31 +30,31 @@ commands:
   balance:
     name: balance
     description: "Відображає ваш поточний баланс"
-    usage: "&cВикористання: /balance [гравець: string]"
+    usage: "&cВикористання: /balance [player: string]"
     aliases: [ ]
   pay:
     name: pay
     description: "Переказати гроші іншому гравцю"
-    usage: "&cВикористання: /pay <гравець: string> <сума: number>"
+    usage: "&cВикористання: /pay <player: string> <amount: number>"
     aliases: [ ]
   rich:
     name: rich
     description: "Відображає найбагатших гравців"
-    usage: "&cВикористання: /rich [сторінка: number]"
+    usage: "&cВикористання: /rich [page: number]"
     aliases: [ ]
   add-balance:
     name: addbalance
     description: "Додає гроші на баланс гравця"
-    usage: "&cВикористання: /addbalance <гравець: string> <сума: number>"
+    usage: "&cВикористання: /addbalance <player: string> <amount: number>"
     aliases: [ ]
   remove-balance:
     name: removebalance
     description: "Знімає гроші з балансу гравця"
-    usage: "&cВикористання: /removebalance <гравець: string> <сума: number>"
+    usage: "&cВикористання: /removebalance <player: string> <amount: number>"
     aliases: [ ]
   set-balance:
     name: setbalance
     description: "Встановлює баланс гравця"
-    usage: "&cВикористання: /setbalance <гравець: string> <сума: number>"
+    usage: "&cВикористання: /setbalance <player: string> <amount: number>"
     aliases: [ ]
 ...

--- a/resources/languages/vi-VN.yml
+++ b/resources/languages/vi-VN.yml
@@ -30,31 +30,31 @@ commands:
   balance:
     name: balance
     description: Hiển thị số dư hiện tại của bạn
-    usage: "&cCách dùng /balance [người chơi: string]"
+    usage: "&cCách dùng /balance [player: string]"
     aliases: [ ]
   pay:
     name: pay
     description: Trả tiền cho người khác từ số dư của bạn
-    usage: "&cCách dùng /pay <người chơi: string> <số tiền: number>"
+    usage: "&cCách dùng /pay <player: string> <amount: number>"
     aliases: [ ]
   rich:
     name: rich
     description: Hiển thị danh sách người giàu nhất
-    usage: "&cCách dùng /rich [trang: number]"
+    usage: "&cCách dùng /rich [page: number]"
     aliases: [ ]
   add-balance:
     name: addbalance
     description: Thêm tiền vào tài khoản của người chơi
-    usage: "&cCách dùng /addbalance <người chơi: string> <số tiền: number>"
+    usage: "&cCách dùng /addbalance <player: string> <amount: number>"
     aliases: [ ]
   remove-balance:
     name: removebalance
     description: Trừ tiền từ tài khoản của người chơi
-    usage: "&cCách dùng /removebalance <người chơi: string> <số tiền: number>"
+    usage: "&cCách dùng /removebalance <player: string> <amount: number>"
     aliases: [ ]
   set-balance:
     name: setbalance
     description: Đặt số dư của người chơi
-    usage: "&cCách dùng /setbalance <người chơi: string> <số tiền: number>"
+    usage: "&cCách dùng /setbalance <player: string> <amount: number>"
     aliases: [ ]
 ... 

--- a/src/cooldogedev/BedrockEconomy/language/LanguageManager.php
+++ b/src/cooldogedev/BedrockEconomy/language/LanguageManager.php
@@ -40,6 +40,8 @@ final class LanguageManager
         "de-CH",
         "en-US",
         "es-ES",
+        "ru-RU",
+        "uk-UA",
         "vi-VN"
     ];
 


### PR DESCRIPTION
This PR adds support for Ukrainian and Russian languages.

- Added `uk-UA.yml` and `ru-RU.yml` language files.
- Registered the new languages in the source code.
- Updated the Vietnamese translation for consistency with the German and Spanish language files.