### PR TITLE
Update GitHub Actions workflow to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ jobs:
     name: build phar
     permissions:
       contents: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -20,7 +20,7 @@ jobs:
         with:
           additional-assets: |
             icon.png
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: BedrockEconomy.phar
           path: ${{steps.pharynx.outputs.output-phar}}


### PR DESCRIPTION
Ubuntu 20.04 doesn't support anymore.